### PR TITLE
Add home-manager package to home.nix

### DIFF
--- a/02-basic-repository-setup.md
+++ b/02-basic-repository-setup.md
@@ -86,6 +86,7 @@ yet. You're almost there, answers are coming.
 {
   home = {
     packages = with pkgs; [
+      home-manager
       hello
     ];
 


### PR DESCRIPTION
Without this, I could not run any home-manager commands after running the initial `make`. I may have missed something (I don't think so), but it worked after adding this.