### PR TITLE
Fixing error in the evaluation of an example function

### DIFF
--- a/04-explain-outputs-function.md
+++ b/04-explain-outputs-function.md
@@ -170,7 +170,7 @@ But you can't use anything declared here outside that expression:
 
 ```nix
 {
-  # Evaluates to 5
+  # Evaluates to 7
   first = let
     a = 2;
     b = a + 3;


### PR DESCRIPTION
I believe first should evaluate to 7 since:
a = 2
b = a + 3 = 5
and therefore 
first = 2 + 5 = 7

you could also consider removing the brackets in the code snippet since the other examples don't have them