### PR TITLE
Fix the Home Manager NixOS install link

### DIFF
--- a/01-install.md
+++ b/01-install.md
@@ -47,7 +47,7 @@ it later.
 [Install Home Manager](https://nix-community.github.io/home-manager/index.xhtml#ch-installation).
 
 If you're here reading this, you want the standalone. If you're on NixOS,
-install it as a [package via NixOS](https://search.nixos.org/packages?channel=23.11&show=home-manager&from=0&size=50&sort=relevance&type=packages&query=home-manager).
+install it as a [package via NixOS](https://search.nixos.org/packages?show=home-manager&query=home-manager).
 
 Make sure you follow step 4:
 


### PR DESCRIPTION
It was pointing to an hardcoded Nix channel, we can just remove it so it always points to the latest one. :)

---

Thank you for making this guide!